### PR TITLE
JS-0417-issue-fixe

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { Search, Filter, Star, Users, Briefcase, Award } from 'lucide-react'
 import Header from '../components/Header'
@@ -117,6 +117,21 @@ export default function HomePage() {
     }
   }, []);
 
+  // Memoized handlers for each skill
+  const skillChangeHandlers = useMemo(() => {
+    const handlers: { [skill: string]: (e: React.ChangeEvent<HTMLInputElement>) => void } = {};
+    [
+      'JavaScript', 'TypeScript', 'React', 'Vue', 'Angular', 'Node.js',
+      'Python', 'Java', 'C#', 'PHP', 'Ruby', 'Go', 'Rust', 'HTML', 'CSS', 'Sass', 'Tailwind CSS', 'Bootstrap',
+      'MongoDB', 'PostgreSQL', 'MySQL', 'Redis', 'Docker', 'Kubernetes', 'AWS', 'Azure', 'Google Cloud',
+      'Git', 'GitHub', 'CI/CD', 'Testing', 'DevOps', 'UI/UX', 'Design', 'Mobile', 'iOS', 'Android',
+      'Machine Learning', 'AI', 'Data Science', 'Blockchain'
+    ].forEach(skill => {
+      handlers[skill] = handleSkillChange(skill);
+    });
+    return handlers;
+  }, [handleSkillChange]);
+
   const skeletonKeys = ['skel1', 'skel2', 'skel3', 'skel4', 'skel5', 'skel6'];
 
   return (
@@ -196,7 +211,7 @@ export default function HomePage() {
                       <input
                         type="checkbox"
                         checked={selectedSkills.includes(skill)}
-                        onChange={handleSkillChange(skill)}
+                        onChange={skillChangeHandlers[skill]}
                         className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                       />
                       <span className="ml-2 text-sm text-gray-700">{skill}</span>

--- a/frontend/app/projects/page.tsx
+++ b/frontend/app/projects/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { Search, Filter, Briefcase } from 'lucide-react'
 import Header from '../../components/Header'

--- a/frontend/components/FilterBar.tsx
+++ b/frontend/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
 import { Filter, X } from 'lucide-react'
 
 interface FilterBarProps {
@@ -47,6 +47,22 @@ export default function FilterBar({ selectedSkills, onSkillsChange }: FilterBarP
     setIsOpen(false);
   }, []);
 
+  // Memoized handlers for each skill
+  const toggleSkillHandlers = useMemo(() => {
+    const handlers: { [skill: string]: () => void } = {};
+    commonSkills.forEach(skill => {
+      handlers[skill] = () => handleToggleSkill(skill);
+    });
+    return handlers;
+  }, [handleToggleSkill]);
+  const selectedSkillHandlers = useMemo(() => {
+    const handlers: { [skill: string]: () => void } = {};
+    selectedSkills.forEach(skill => {
+      handlers[skill] = () => handleToggleSkill(skill);
+    });
+    return handlers;
+  }, [selectedSkills, handleToggleSkill]);
+
   // The filter content (used in both modal and sidebar)
   const filterContent = (
     <div className="w-full max-w-xs mx-auto md:max-w-none md:w-full">
@@ -77,7 +93,7 @@ export default function FilterBar({ selectedSkills, onSkillsChange }: FilterBarP
               >
                 {skill}
                 <button
-                  onClick={() => handleToggleSkill(skill)}
+                  onClick={selectedSkillHandlers[skill]}
                   className="ml-1 hover:text-red-600"
                 >
                   <X className="w-3 h-3" />
@@ -100,7 +116,7 @@ export default function FilterBar({ selectedSkills, onSkillsChange }: FilterBarP
               <input
                 type="checkbox"
                 checked={selectedSkills.includes(skill)}
-                onChange={() => handleToggleSkill(skill)}
+                onChange={toggleSkillHandlers[skill]}
                 className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
               />
               <span className="text-sm text-gray-700">{skill}</span>

--- a/frontend/src/components/Chat/ConversationList.tsx
+++ b/frontend/src/components/Chat/ConversationList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useRouter } from 'next/navigation';
 import { connectSocket } from '../../utils/socket';
@@ -94,6 +94,15 @@ const ConversationList: React.FC<ConversationListProps> = ({ selectedConversatio
     handleSelect(id);
   }, [handleSelect]);
 
+  // Memoized handlers for each conversation id
+  const listItemClickHandlers = useMemo(() => {
+    const handlers: { [id: number]: () => void } = {};
+    conversations.forEach(conv => {
+      handlers[conv.id] = () => handleListItemClick(conv.id);
+    });
+    return handlers;
+  }, [conversations, handleListItemClick]);
+
   if (loading) return <div className="text-center text-gray-400 py-8">Loading...</div>;
   if (error) return <div className="text-center text-red-500 py-8">{error}</div>;
   if (conversations.length === 0) return <div className="text-center text-gray-400 py-8">No conversations yet.</div>;
@@ -109,7 +118,7 @@ const ConversationList: React.FC<ConversationListProps> = ({ selectedConversatio
             <li
               key={conv.id}
               className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition border hover:bg-gray-100 ${selectedConversation === conv.id ? 'bg-blue-50 border-blue-400' : isUnread ? 'bg-blue-100 border-blue-300' : 'bg-white border-transparent'}`}
-              onClick={() => handleListItemClick(conv.id)}
+              onClick={listItemClickHandlers[conv.id]}
             >
               <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-lg font-bold text-gray-500">
                 {conv.avatarUrl ? (

--- a/frontend/src/components/Dashboard/UserDashboard.tsx
+++ b/frontend/src/components/Dashboard/UserDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { useAuth } from '../../contexts/AuthContext';
 import { 
@@ -156,6 +156,15 @@ const UserDashboard: React.FC = () => {
     window.location.href = '/chat';
   }, []);
 
+  // Memoized navigation handlers
+  const navHandlers = useMemo(() => ({
+    post: () => window.location.href = '/post',
+    projects: handleNavigateToProjects,
+    chat: handleNavigateToChat,
+    browse: () => window.location.href = '/projects',
+    search: () => window.location.href = '/search',
+  }), [handleNavigateToProjects, handleNavigateToChat]);
+
   const StatCard = ({ title, value, icon: Icon, color, trend }: StatCardProps) => (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -262,19 +271,19 @@ const UserDashboard: React.FC = () => {
             <p className="text-lg md:text-xl text-blue-100 mb-4">Your freelance business at a glance.</p>
             <div className="flex gap-3 mt-4">
               <button
-                onClick={() => window.location.href = '/post'}
+                onClick={navHandlers.post}
                 className="bg-white/90 hover:bg-white text-blue-700 font-semibold px-5 py-2 rounded-lg shadow transition flex items-center gap-2"
               >
                 <Briefcase className="w-5 h-5" /> Post Project
               </button>
               <button
-                onClick={() => window.location.href = '/projects'}
+                onClick={navHandlers.browse}
                 className="bg-white/90 hover:bg-white text-purple-700 font-semibold px-5 py-2 rounded-lg shadow transition flex items-center gap-2"
               >
                 <Search className="w-5 h-5" /> Browse Projects
               </button>
               <button
-                onClick={() => window.location.href = '/chat'}
+                onClick={navHandlers.chat}
                 className="bg-white/90 hover:bg-white text-green-700 font-semibold px-5 py-2 rounded-lg shadow transition flex items-center gap-2"
               >
                 <MessageSquare className="w-5 h-5" /> Messages

--- a/frontend/src/components/Search/AdvancedSearch.tsx
+++ b/frontend/src/components/Search/AdvancedSearch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
   Search, 
@@ -238,6 +238,33 @@ const AdvancedSearch: React.FC = () => {
     </motion.div>
   );
 
+  // Memoized handlers for removing skills from filters
+  const filterRemoveHandlers = useMemo(() => {
+    const handlers: { [skill: string]: () => void } = {};
+    filters.skills.forEach(skill => {
+      handlers[skill] = () => handleFilterRemove(skill);
+    });
+    return handlers;
+  }, [filters.skills, handleFilterRemove]);
+
+  // Memoized handlers for suggestion button clicks
+  const suggestionClickHandlers = useMemo(() => {
+    const handlers: { [text: string]: () => void } = {};
+    suggestions.forEach(suggestion => {
+      handlers[suggestion.text] = () => handleSuggestionButtonClick(suggestion);
+    });
+    return handlers;
+  }, [suggestions, handleSuggestionButtonClick]);
+
+  // Memoized handlers for trending skill clicks
+  const trendingSkillHandlers = useMemo(() => {
+    const handlers: { [skill: string]: () => void } = {};
+    trendingSkills.forEach(skillObj => {
+      handlers[skillObj.skill] = () => handleSkillClick(skillObj.skill);
+    });
+    return handlers;
+  }, [trendingSkills, handleSkillClick]);
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -284,7 +311,7 @@ const AdvancedSearch: React.FC = () => {
                 {suggestions.map((suggestion) => (
                   <button
                     key={suggestion.text}
-                    onClick={() => handleSuggestionButtonClick(suggestion)}
+                    onClick={suggestionClickHandlers[suggestion.text]}
                     className="w-full text-left px-4 py-3 hover:bg-gray-50 flex items-center"
                   >
                     <Search className="w-4 h-4 text-gray-400 mr-3" />
@@ -311,7 +338,7 @@ const AdvancedSearch: React.FC = () => {
                   <FilterChip
                     key={skill}
                     label={skill}
-                    onRemove={() => handleFilterRemove(skill)}
+                    onRemove={filterRemoveHandlers[skill]}
                   />
                 ))}
                 {filters.location && (
@@ -471,7 +498,7 @@ const AdvancedSearch: React.FC = () => {
                     key={skill.skill}
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
-                    onClick={() => handleSkillClick(skill.skill)}
+                    onClick={trendingSkillHandlers[skill.skill]}
                     className="px-3 py-1 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-full text-sm font-medium hover:shadow-md transition-all"
                   >
                     {skill.skill}


### PR DESCRIPTION
Using .bind() or passing local callback functions as props to react component incurs a performance overhead. Consider using React.useCallback, or if possible, moving the callback definition outside the component.

EXCEPTIONS: This rule may not apply if your react component is only rendered once, or if your application is not performance sensitive. In such cases, consider adding a [skipcq](https://deepsource.com/blog/releases-silence-issues-in-code) to prevent DeepSource from raising this issue on a single component. Alternatively, for small applications, you could add this issue in the [ignore rules section](https://docs.deepsource.com/docs/repository-view-issues#ignoring-issues).

Note that the performance overhead is not determined by the size of the callback function, but instead the number of times the component is rendered.

If the callback passed to a prop is local to the render function, it will get recreated every time the component renders. This affects performance by causing unnecessary re-renders if a brand new function is passed as a property to a component that uses a reference equality check on the property to determine if it should update. Using the useCallback hook on functional components, or a method on class components is more performant.

## Summary by Sourcery

Replace inline callback definitions with memoized handler functions using useMemo across multiple React components to improve performance and prevent unnecessary re-renders.

Enhancements:
- Memoize filter removal, suggestion click, and trending skill handlers in AdvancedSearch to replace inline callbacks
- Use useMemo to build toggle and selection handler mappings in FilterBar instead of inline arrow functions
- Replace inline change handlers in HomePage skill checkboxes with memoized handlers to avoid recreating functions on each render
- Introduce memoized navigation callbacks in UserDashboard to prevent recreation of inline URL navigation functions
- Add useMemo-based click handlers in ConversationList for selecting conversations to eliminate inline callback definitions